### PR TITLE
boto3 1.2.3 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ Pygments==1.6
 Paver==1.2.1
 colorama==0.2.7
 ipython
+configparser==3.5.0b2
 
 # Cli
 Click==5.1

--- a/s3keyring/cli.py
+++ b/s3keyring/cli.py
@@ -11,7 +11,7 @@ import os
 
 def _get_default_config_file():
     """Gets the full path to the default config file"""
-    project_file = os.path.join(os.path.curdir, '.s3keyring.ini')
+    project_file = os.path.join(os.path.curdir, 's3keyring.ini')
     if os.path.isfile(project_file):
         return project_file
     else:

--- a/s3keyring/config.py
+++ b/s3keyring/config.py
@@ -45,10 +45,10 @@ class Config:
     def get_profile(self, profile_name):
         """Returns a dict-like object with profile options"""
         section = "profile:{}".format(profile_name)
-        if section not in self.config:
+        if not self.config.has_section(section):
             raise ProfileNotFoundError(
                 "Profile {} not found".format(profile_name))
-        return self.config[section]
+        return dict(self.config.items(section))
 
     def remove_profile(self, profile_name):
         """Removes a profile, if it exists. Otherwise does nothing."""

--- a/s3keyring/metadata.py
+++ b/s3keyring/metadata.py
@@ -8,7 +8,7 @@ Information describing the project.
 package = 's3keyring'
 project = "S3 backend for the keyring module"
 project_no_spaces = project.replace(' ', '')
-version = '0.6.0.post1'
+version = '0.6.0.post2'
 description = 'Keeps your secrets safe in S3'
 authors = ['German Gomez-Herrero']
 authors_string = ', '.join(authors)

--- a/s3keyring/metadata.py
+++ b/s3keyring/metadata.py
@@ -8,7 +8,7 @@ Information describing the project.
 package = 's3keyring'
 project = "S3 backend for the keyring module"
 project_no_spaces = project.replace(' ', '')
-version = '0.6'
+version = '0.6post1'
 description = 'Keeps your secrets safe in S3'
 authors = ['German Gomez-Herrero']
 authors_string = ', '.join(authors)

--- a/s3keyring/metadata.py
+++ b/s3keyring/metadata.py
@@ -8,7 +8,7 @@ Information describing the project.
 package = 's3keyring'
 project = "S3 backend for the keyring module"
 project_no_spaces = project.replace(' ', '')
-version = '0.6.0.post2'
+version = '0.6.0.post3'
 description = 'Keeps your secrets safe in S3'
 authors = ['German Gomez-Herrero']
 authors_string = ', '.join(authors)

--- a/s3keyring/metadata.py
+++ b/s3keyring/metadata.py
@@ -8,7 +8,7 @@ Information describing the project.
 package = 's3keyring'
 project = "S3 backend for the keyring module"
 project_no_spaces = project.replace(' ', '')
-version = '0.6post1'
+version = '0.6.0.post1'
 description = 'Keeps your secrets safe in S3'
 authors = ['German Gomez-Herrero']
 authors_string = ', '.join(authors)

--- a/s3keyring/s3.py
+++ b/s3keyring/s3.py
@@ -10,6 +10,7 @@ from keyring.errors import (PasswordDeleteError)
 from keyring.backend import KeyringBackend
 from boto3.session import Session
 from botocore.exceptions import EndpointConnectionError
+from botocore.client import Config as BotoConfig
 from s3keyring.exceptions import ProfileNotFoundError
 import string
 import six
@@ -97,7 +98,7 @@ class S3Backed(object):
     def bucket(self):
         if self.__bucket is None:
             bucket_name = self.profile['bucket']
-            self.__bucket = self.session.resource('s3').Bucket(bucket_name)
+            self.__bucket = self.session.resource('s3', config=BotoConfig(signature_version='s3v4')).Bucket(bucket_name)
         return self.__bucket
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -260,6 +260,7 @@ setup_dict = dict(
         'keyring',
         'boto3>=1.2.3',
         'awscli',
+        'configparser'
     ] + python_version_specific_requires,
     # Allow tests to be run with `python setup.py test'.
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,7 @@ setup_dict = dict(
         'keyring',
         'boto3>=1.2.3',
         'awscli',
-        'configparser'
+        'configparser==3.5.0b2'
     ] + python_version_specific_requires,
     # Allow tests to be run with `python setup.py test'.
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,7 @@ setup_dict = dict(
         'keyring',
         'boto3>=1.2.3',
         'awscli',
-        'configparser==3.5.0b2'
+        'configparser>=3.5.0b2'
     ] + python_version_specific_requires,
     # Allow tests to be run with `python setup.py test'.
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -258,7 +258,7 @@ setup_dict = dict(
     install_requires=[
         'click>=5.1',
         'keyring',
-        'boto3',
+        'boto3>=1.2.3',
         'awscli',
     ] + python_version_specific_requires,
     # Allow tests to be run with `python setup.py test'.


### PR DESCRIPTION
Hey, first of all thank you very much for sharing this, I've been beating around this idea of using KMS and S3 to store passwords for a while and just when I finally found some time and began working on it I found your project and it saved me a bunch of time already.

Secondly I found that setting S3 signature version by default to v4 breaks aws s3 cli for me and boto3 1.2.3 Session.resource() constructor now allows to pass a boto config which is more convenient than setting it globally in ~/.aws/config.

Also I found that in Python 2.7.10 configparser.ConfigParser().has_section() does not return a dict, but a list of tuples instead, and the ConfigParser() object itself is not iterable, so I had to fix a couple of things in the get_profile method. I am not sure if these changes will be compatible with the version of Python you are using, so let me know and maybe I could find a better way to do this.

Cheers!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/innovativetravel/s3-keyring/1)
<!-- Reviewable:end -->
