### PR TITLE
Put secret using text/plain content type

### DIFF
--- a/s3keyring/s3.py
+++ b/s3keyring/s3.py
@@ -150,9 +150,13 @@ class S3Keyring(S3Backed, KeyringBackend):
         # Save in S3 using both server and client side encryption
         keyname = self._get_s3_key(service, username)
         try:
-            self.bucket.Object(keyname).put(ACL='private', Body=pwd_base64,
-                                            ServerSideEncryption='aws:kms',
-                                            SSEKMSKeyId=self.kms_key_id)
+            self.bucket.Object(keyname).put(
+                ACL='private',
+                Body=pwd_base64,
+                ContentType='text/plain',
+                ServerSideEncryption='aws:kms',
+                SSEKMSKeyId=self.kms_key_id
+            )
         except EndpointConnectionError:
             if self.use_local_keyring:
                 # Can't connect to S3: fallback to OS keyring


### PR DESCRIPTION
This allows secrets to be retrievable using the terraform data source [`s3_bucket_object`](https://www.terraform.io/docs/providers/aws/d/s3_bucket_object.html)

@germangh 